### PR TITLE
add error emitting on send and cover memory leak

### DIFF
--- a/lib/transports/ws2.js
+++ b/lib/transports/ws2.js
@@ -1559,7 +1559,10 @@ class WSv2 extends EventEmitter {
       this.emit('error', new Error('connection currently closing'))
     } else {
       debug('sending %j', msg)
-      this._ws.send(JSON.stringify(msg))
+      this._ws.send(JSON.stringify(msg), (err) => {
+        if (!err) { return }
+        this.emit('error', err)
+      })
     }
   }
 

--- a/lib/ws2_manager.js
+++ b/lib/ws2_manager.js
@@ -287,37 +287,31 @@ class WS2Manager extends EventEmitter {
     ws.on('subscribed', (msg = {}) => {
       this.emit('subscribed', msg)
 
-      const i = wsState.pendingSubscriptions.find(sub => {
+      const beforeLength = wsState.pendingSubscriptions.length
+      wsState.pendingSubscriptions = wsState.pendingSubscriptions.filter(sub => {
         const fv = _pick(msg, Object.keys(sub[1]))
 
-        return (
-          (sub[0] === msg.channel) &&
-          _isEqual(fv, sub[1])
-        )
+        const match = (sub[0] === msg.channel) && _isEqual(fv, sub[1])
+        return !match
       })
 
-      if (i === -1) {
+      if (beforeLength === wsState.pendingSubscriptions.length) {
         debug('error removing pending sub: %j', msg)
-        return
       }
-
-      wsState.pendingSubscriptions.splice(i, 1)
     })
 
     ws.on('unsubscribed', (msg = {}) => {
       this.emit('unsubscribed', msg)
 
       const { chanId } = msg
-      const i = wsState.pendingUnsubscriptions.findIndex(cid => (
-        cid === `${chanId}`
+      const beforeLength = wsState.pendingUnsubscriptions.length
+      wsState.pendingUnsubscriptions = wsState.pendingUnsubscriptions.filter(cid => (
+        cid !== `${chanId}`
       ))
 
-      if (i === -1) {
+      if (beforeLength === wsState.pendingUnsubscriptions.length) {
         debug('error removing pending unsub: %j', msg)
-        return
       }
-
-      wsState.pendingUnsubscriptions.splice(i, 1)
     })
 
     if (apiKey && apiSecret) { // auto-auth


### PR DESCRIPTION
### Description:
Add error emitting on sending failure and cover memory leaks of pending un/subscription (because of underlying ws subscription failure)
